### PR TITLE
D10-87: Allow D10.

### DIFF
--- a/dgi_3d_solution.info.yml
+++ b/dgi_3d_solution.info.yml
@@ -1,7 +1,7 @@
 name: DGI 3D Solution
 description: A module to handle 3D objects in the context of Islandora.
 type: module
-core_version_requirement: ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - islandora:islandora_core_feature
   - migrate_plus:migrate_plus


### PR DESCRIPTION
Oddities... `upgrade_status` has a strange error with this, as this module doesn't actually contain any PHP code:

File name | Line | Error
-- | -- | --
web/PHPStan failed | 0 | PHPStan command failed: /usr/bin/php  /var/www/html/vendor/bin/phpstan analyse --memory-limit=1500M  --error-format=json  --configuration=/tmp/upgrade_status/deprecation_testing.neon  /var/www/html/web/modules/contrib/dgi_3d_solution Command output: Empty. Command error: ! [NOTE] No files found to analyse. [WARNING] This will cause a non-zero exit code in PHPStan 2.0.

Not terribly concerned, but... does somewhat call in to question why we bothered making this standalone?